### PR TITLE
path fix + compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder /app/internal/migration/migrations /app/internal/migration/m
 COPY config/config.docker.yaml /app/config/config.yaml
 COPY scripts/wrapper.sh /app/wrapper.sh
 
-VOLUME ["/uploads", "/config", "/data"]
+VOLUME ["/app/uploads", "/app/config", "/app/data"]
 EXPOSE ${PORT}
 
 CMD ["/app/wrapper.sh"]

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ A temporary file hosting service built with Echo, inspired by [0x0.st](https://0
    ```bash
    # Option 1: Use pre-built image (recommended)
    docker pull ghcr.io/marianozunino/drop:latest
-   docker run -p 3000:3000 -v ./uploads:/uploads -v ./config:/config -v ./data:/data ghcr.io/marianozunino/drop:latest
+   docker run -p 3000:3000 -v ./uploads:/app/uploads -v ./config:/app/config -v ./data:/app/data ghcr.io/marianozunino/drop:latest
    
    # Option 2: Build from source
    docker build -t drop .
-   docker run -p 3000:3000 -v ./uploads:/uploads -v ./config:/config -v ./data:/data drop
+   docker run -p 3000:3000 -v ./uploads:/app/uploads -v ./config:/app/config -v ./data:/app/data drop
    ```
 
 ## Configuration

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  drop:
+    image: ghcr.io/marianozunino/drop:latest
+    restart: unless-stopped
+    container_name: drop
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./uploads:/app/uploads
+      - ./data:/app/data
+      - ./config:/app/config

--- a/config/config.docker.yaml
+++ b/config/config.docker.yaml
@@ -12,7 +12,7 @@ max_age_days: 365
 max_size_mib: 1024
 
 # upload_path: Filesystem path where uploaded files are stored
-upload_path: /uploads
+upload_path: /app/uploads
 
 # check_interval_min: How often (in minutes) to check for expired files
 check_interval_min: 1
@@ -24,7 +24,7 @@ expiration_manager_enabled: true
 base_url: "http://localhost:3000/"
 
 # sqlite_path: Path to SQLite database file for metadata
-sqlite_path: "/data/dump.db"
+sqlite_path: "/app/data/dump.db"
 
 # id_length: Length of random IDs generated for files
 id_length: 4

--- a/scripts/wrapper.sh
+++ b/scripts/wrapper.sh
@@ -4,14 +4,14 @@ set -e
 echo "Starting Drop service with migrations..."
 
 # Ensure data directory exists
-mkdir -p /data
+mkdir -p /app/data
 
 # Also ensure uploads directory exists  
-mkdir -p /uploads
+mkdir -p /app/uploads
 
 # Run migrations
 echo "Running database migrations..."
-/app/migrate -action up -db /data/dump.db
+/app/migrate -action up -db /app/data/dump.db
 
 echo "Migrations completed successfully"
 echo "Starting Drop service..."


### PR DESCRIPTION
Hi! In [wrapper.sh](https://github.com/marianozunino/drop/blob/95159b1bc53e520044443c9397c1a94d809af8cb/scripts/wrapper.sh) `CONFIG_PATH` is set to `/app/config/config.yaml`, but in the example Docker setup the `config` directory is mounted to `/config` so the custom `config.yaml` is ignored.