### PR TITLE
fix: URL shortening bug and apply filename sanitization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
 .task
 uploads
 badger
-bin
-data/dump.db
+bin/
+
+# Binaries
+drop
+migrate
+client
+
+# Database files
+*.db
+*.db-shm
+*.db-wal
+data/

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -64,8 +64,13 @@ func (db *DB) StoreMetadata(metadata Storeable) error {
 	}
 	defer stmt.Close()
 
+	idValue := fileMeta.ResourcePath
+	if idValue == "" {
+		idValue = metadata.ID()
+	}
+
 	_, err = stmt.Exec(
-		metadata.ID(),
+		idValue,
 		fileMeta.ResourcePath,
 		fileMeta.Token,
 		fileMeta.OriginalName,

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -146,6 +146,245 @@ func TestGetMetadataByIDNotFound(t *testing.T) {
 	assert.Empty(t, metadata.ResourcePath)
 }
 
+func TestMetadataConsistencyAfterUpdate(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	now := time.Now()
+	originalExpiresAt := now.Add(24 * time.Hour)
+	newExpiresAt := now.Add(48 * time.Hour)
+
+	originalMetadata := &model.FileMetadata{
+		ResourcePath:   "test123",
+		Token:          "token-123",
+		OriginalName:   "URL Shortener",
+		UploadDate:     now,
+		ExpiresAt:      &originalExpiresAt,
+		Size:           0,
+		ContentType:    "text/html",
+		OneTimeView:    false,
+		OriginalURL:    "https://www.example.com",
+		IsURLShortener: true,
+		AccessCount:    0,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	err := db.StoreMetadata(originalMetadata)
+	require.NoError(t, err)
+
+	metadata1, err := db.GetMetadataByID("test123")
+	require.NoError(t, err)
+	assert.Equal(t, "test123", metadata1.ResourcePath)
+	assert.Equal(t, originalExpiresAt.Unix(), metadata1.ExpiresAt.Unix())
+
+	updatedMetadata := model.FileMetadata{
+		ResourcePath:   "test123",
+		Token:          "token-123",
+		OriginalName:   "URL Shortener",
+		UploadDate:     now,
+		ExpiresAt:      &newExpiresAt,
+		Size:           0,
+		ContentType:    "text/html",
+		OneTimeView:    true,
+		OriginalURL:    "https://www.example.com/updated",
+		IsURLShortener: true,
+		AccessCount:    5,
+		CreatedAt:      now,
+		UpdatedAt:      now.Add(time.Hour),
+	}
+
+	err = db.StoreMetadata(&updatedMetadata)
+	require.NoError(t, err)
+
+	var dbId, dbResourcePath string
+	err = db.DB.QueryRow("SELECT id, resource_path FROM metadata WHERE id = ?", "test123").Scan(&dbId, &dbResourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, "test123", dbId, "Database id should be 'test123'")
+	assert.Equal(t, "test123", dbResourcePath, "Database resource_path should be 'test123'")
+	assert.Equal(t, dbId, dbResourcePath, "id and resource_path must always match")
+
+	metadata2, err := db.GetMetadataByID("test123")
+	require.NoError(t, err)
+	assert.Equal(t, "test123", metadata2.ResourcePath, "ResourcePath should still be 'test123'")
+	assert.Equal(t, newExpiresAt.Unix(), metadata2.ExpiresAt.Unix(), "Expiration should be updated")
+	assert.True(t, metadata2.OneTimeView, "OneTimeView should be updated to true")
+	assert.Equal(t, "https://www.example.com/updated", metadata2.OriginalURL, "OriginalURL should be updated")
+	assert.Equal(t, 5, metadata2.AccessCount, "AccessCount should be updated")
+
+	metadata3, err := db.GetMetadataByID("test123")
+	require.NoError(t, err)
+	assert.Equal(t, "test123", metadata3.ResourcePath)
+}
+
+func TestStoreMetadataEnforcesIdResourcePathConsistency(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	now := time.Now()
+	expiresAt := now.Add(24 * time.Hour)
+
+	metadata1 := &model.FileMetadata{
+		ResourcePath:   "abc123",
+		Token:          "token-abc",
+		OriginalName:   "Test File 1",
+		UploadDate:     now,
+		ExpiresAt:      &expiresAt,
+		Size:           1024,
+		ContentType:    "text/plain",
+		OneTimeView:    false,
+		IsURLShortener: false,
+		AccessCount:    0,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	err := db.StoreMetadata(metadata1)
+	require.NoError(t, err)
+
+	var dbId, dbResourcePath string
+	err = db.DB.QueryRow("SELECT id, resource_path FROM metadata WHERE id = ?", "abc123").Scan(&dbId, &dbResourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", dbId, "Database id must match ResourcePath")
+	assert.Equal(t, "abc123", dbResourcePath, "Database resource_path must match ResourcePath")
+	assert.Equal(t, dbId, dbResourcePath, "id and resource_path must always be identical after StoreMetadata")
+
+	_, err = db.DB.Exec(`
+		INSERT INTO metadata (
+			id, resource_path, token, original_name, upload_date, expires_at, 
+			size, content_type, one_time_view, original_url, is_url_shortener,
+			access_count, ip_address, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, "mismatch_id", "different_path", "token-mismatch", "Mismatch Test", now, nil, 0, "text/plain", false, "", false, 0, "", now, now)
+	require.NoError(t, err)
+
+	count := 0
+	err = db.DB.QueryRow("SELECT COUNT(*) FROM metadata WHERE id != resource_path").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "We manually created one inconsistent record")
+
+	metadata2 := &model.FileMetadata{
+		ResourcePath:   "xyz789",
+		Token:          "token-xyz",
+		OriginalName:   "Test File 2",
+		UploadDate:     now,
+		ExpiresAt:      &expiresAt,
+		Size:           2048,
+		ContentType:    "application/json",
+		OneTimeView:    true,
+		IsURLShortener: false,
+		AccessCount:    0,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	err = db.StoreMetadata(metadata2)
+	require.NoError(t, err)
+
+	err = db.DB.QueryRow("SELECT id, resource_path FROM metadata WHERE id = ?", "xyz789").Scan(&dbId, &dbResourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, "xyz789", dbId, "StoreMetadata must ensure id matches ResourcePath")
+	assert.Equal(t, "xyz789", dbResourcePath, "StoreMetadata must ensure resource_path matches ResourcePath")
+	assert.Equal(t, dbId, dbResourcePath, "StoreMetadata must enforce id == resource_path")
+
+	metadata3 := &model.FileMetadata{
+		ResourcePath:   "url456",
+		Token:          "token-url",
+		OriginalName:   "URL Shortener",
+		UploadDate:     now,
+		ExpiresAt:      &expiresAt,
+		Size:           0,
+		ContentType:    "text/html",
+		OneTimeView:    false,
+		OriginalURL:    "https://example.com",
+		IsURLShortener: true,
+		AccessCount:    0,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	err = db.StoreMetadata(metadata3)
+	require.NoError(t, err)
+
+	err = db.DB.QueryRow("SELECT id, resource_path FROM metadata WHERE id = ?", "url456").Scan(&dbId, &dbResourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, "url456", dbId, "For URL shorteners, id must match ResourcePath")
+	assert.Equal(t, "url456", dbResourcePath, "For URL shorteners, resource_path must match ResourcePath")
+	assert.Equal(t, dbId, dbResourcePath, "For URL shorteners, id and resource_path must always match")
+
+	count = 0
+	err = db.DB.QueryRow("SELECT COUNT(*) FROM metadata WHERE id != resource_path").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "Only the manually created inconsistent record should exist. All StoreMetadata calls must create consistent records.")
+
+	rows, err := db.DB.Query("SELECT id, resource_path FROM metadata WHERE id = resource_path")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	consistentCount := 0
+	for rows.Next() {
+		var id, path string
+		err = rows.Scan(&id, &path)
+		require.NoError(t, err)
+		assert.Equal(t, id, path, "Every record created by StoreMetadata must have id == resource_path")
+		consistentCount++
+	}
+	require.NoError(t, rows.Err())
+	assert.GreaterOrEqual(t, consistentCount, 3, "At least 3 consistent records should exist (abc123, xyz789, url456)")
+
+	var allIds, allPaths []string
+	rows2, err := db.DB.Query("SELECT id, resource_path FROM metadata ORDER BY id")
+	require.NoError(t, err)
+	defer rows2.Close()
+
+	for rows2.Next() {
+		var id, path string
+		err = rows2.Scan(&id, &path)
+		require.NoError(t, err)
+		allIds = append(allIds, id)
+		allPaths = append(allPaths, path)
+	}
+	require.NoError(t, rows2.Err())
+
+	mismatches := 0
+	for i := range allIds {
+		if allIds[i] != allPaths[i] {
+			mismatches++
+			t.Logf("Mismatch found: id=%s, resource_path=%s", allIds[i], allPaths[i])
+		}
+	}
+	assert.Equal(t, 1, mismatches, "Only the manually inserted inconsistent record should have a mismatch. This test verifies StoreMetadata enforces consistency.")
+
+	updateMetadata := &model.FileMetadata{
+		ResourcePath:   "mismatch_id",
+		Token:          "token-updated",
+		OriginalName:   "Updated File",
+		UploadDate:     now,
+		ExpiresAt:      nil,
+		Size:           4096,
+		ContentType:    "application/pdf",
+		OneTimeView:    false,
+		IsURLShortener: false,
+		AccessCount:    5,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	err = db.StoreMetadata(updateMetadata)
+	require.NoError(t, err)
+
+	err = db.DB.QueryRow("SELECT id, resource_path FROM metadata WHERE id = ?", "mismatch_id").Scan(&dbId, &dbResourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, "mismatch_id", dbId, "After INSERT OR REPLACE, id must equal the ResourcePath used")
+	assert.Equal(t, "mismatch_id", dbResourcePath, "After INSERT OR REPLACE, resource_path must equal ResourcePath")
+	assert.Equal(t, dbId, dbResourcePath, "INSERT OR REPLACE must ensure id == resource_path even when replacing existing record")
+
+	count = 0
+	err = db.DB.QueryRow("SELECT COUNT(*) FROM metadata WHERE id != resource_path").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "After INSERT OR REPLACE of the inconsistent record, all records must be consistent. This proves StoreMetadata enforces consistency even when replacing existing records.")
+}
+
 func TestListAllMetadata(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/internal/handler/chunked_upload.go
+++ b/internal/handler/chunked_upload.go
@@ -336,7 +336,7 @@ func (h *Handler) finalizeChunkedUpload(upload *ChunkedUpload, c echo.Context) (
 	metadata := model.FileMetadata{
 		ResourcePath: finalPath,
 		Token:        managementToken,
-		OriginalName: upload.Filename,
+		OriginalName: filenameSanitizer.ReplaceAllString(upload.Filename, ""),
 		UploadDate:   time.Now(),
 		Size:         upload.TotalSize,
 		ContentType:  contentType,

--- a/internal/handler/file_upload.go
+++ b/internal/handler/file_upload.go
@@ -39,7 +39,7 @@ func (h *Handler) HandleUpload(c echo.Context) error {
 		return c.String(http.StatusBadRequest, "Invalid request form.")
 	}
 
-	if c.FormValue("shorten") != "" {
+	if _, exists := c.Request().Form["shorten"]; exists {
 		if !h.cfg.URLShorteningEnabled {
 			return c.String(http.StatusBadRequest, "URL shortening feature is disabled")
 		}
@@ -105,7 +105,7 @@ type FileInfo struct {
 }
 
 func (h *Handler) extractFileContent(c echo.Context) (FileInfo, error) {
-	if c.FormValue("shorten") != "" {
+	if _, exists := c.Request().Form["shorten"]; exists {
 		return FileInfo{}, fmt.Errorf("URL shortening request - handled separately")
 	}
 
@@ -165,7 +165,7 @@ func (h *Handler) saveFromFormFile(file io.Reader, header *multipart.FileHeader)
 	fileInfo := FileInfo{
 		FilePath:         filePath,
 		StoredFilename:   filename,
-		OriginalFilename: header.Filename,
+		OriginalFilename: filenameSanitizer.ReplaceAllString(header.Filename, ""),
 		Size:             size,
 		ContentType:      contentType,
 	}
@@ -209,6 +209,7 @@ func (h *Handler) downloadFromURL(c echo.Context) (FileInfo, error) {
 	}
 
 	originalName := h.extractFilenameFromURL(url)
+	originalName = filenameSanitizer.ReplaceAllString(originalName, "")
 	fileExt := filepath.Ext(originalName)
 	filename := id
 	if fileExt != "" {

--- a/templates/home.templ
+++ b/templates/home.templ
@@ -389,7 +389,9 @@ Valid fields for URL shortening:
   ┌─────────┬────────────┬──────────────────────────────────────────────────┐
   │ field   │ content    │ remarks                                          │
   ╞═════════╪════════════╪══════════════════════════════════════════════════╡
-  │ shorten │ URL        │ The URL to shorten (required)                    │
+  │ shorten │ (ignored)  │ If present, enables URL shortening mode          │
+  ├─────────┼────────────┼──────────────────────────────────────────────────┤
+  │ url     │ URL        │ The URL to shorten (required)                    │
   ├─────────┼────────────┼──────────────────────────────────────────────────┤
   │ secret  │ (ignored)  │ If present, a longer, hard-to-guess URL          │
   │         │            │ will be generated.                               │
@@ -412,22 +414,22 @@ Valid fields for URL shortening:
 templ URLShorteningExamples(config config.Config) {
 	@templ.Raw(`
     Shorten a URL:
-        curl -F'shorten=https://example.com/some/long/url' ` + config.BaseURL + `
+        curl -F'shorten=' -F'url=https://example.com/some/long/url' ` + config.BaseURL + `
 
     Shorten with hard-to-guess URL:
-        curl -F'shorten=https://example.com/some/long/url' -Fsecret= ` + config.BaseURL + `
+        curl -F'shorten=' -F'url=https://example.com/some/long/url' -Fsecret= ` + config.BaseURL + `
 
     Create a one-time short URL (deleted after first access):
-        curl -F'shorten=https://example.com/some/long/url' -Fone_time= ` + config.BaseURL + `
+        curl -F'shorten=' -F'url=https://example.com/some/long/url' -Fone_time= ` + config.BaseURL + `
 
     Shorten with expiration in hours:
-        curl -F'shorten=https://example.com/some/long/url' -Fexpires=24 ` + config.BaseURL + `
+        curl -F'shorten=' -F'url=https://example.com/some/long/url' -Fexpires=24 ` + config.BaseURL + `
 
     Shorten with expiration date:
-        curl -F'shorten=https://example.com/some/long/url' -Fexpires=2023-04-20 ` + config.BaseURL + `
+        curl -F'shorten=' -F'url=https://example.com/some/long/url' -Fexpires=2023-04-20 ` + config.BaseURL + `
 
     Combining options (one-time access with expiration and secret URL):
-        curl -F'shorten=https://example.com/some/long/url' -Fone_time= -Fsecret= -Fexpires=24 ` + config.BaseURL + `
+        curl -F'shorten=' -F'url=https://example.com/some/long/url' -Fone_time= -Fsecret= -Fexpires=24 ` + config.BaseURL + `
 	`)
 }
 


### PR DESCRIPTION
- Ensure id == resource_path consistency in StoreMetadata to prevent URL shortener lookup failures
- Fix URL shortening detection to work with empty shorten field
- Fix documentation with correct curl examples
- Apply filename sanitization to all upload paths


#4 